### PR TITLE
Swap file stream wrapper

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2.0.1 2012-??-??
+2.0.1 2012-07-14
 ChangeLog
 ========
  * fixed #279: segv when cache is full (since 2.0)

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-2.0.1 2012-??-??
+2.0.1 2012-07-14
 ========
  * improve stability
  * admin/ config changed. please update accordingly

--- a/xcache.h
+++ b/xcache.h
@@ -2,7 +2,7 @@
 #define __XCACHE_H
 #define XCACHE_NAME       "XCache"
 #ifndef XCACHE_VERSION
-#	define XCACHE_VERSION "2.0.1-rc3"
+#	define XCACHE_VERSION "2.0.1"
 #endif
 #define XCACHE_AUTHOR     "mOo"
 #define XCACHE_COPYRIGHT  "Copyright (c) 2005-2012"


### PR DESCRIPTION
I had an issue with a proxy file stream wrapper and xcache version 2.0.1 enabled
The file stream wrapper looks like this:
 class FileStreamWrapper
  {
    private static $modified_paths = array();

```
private $path = null;
private $handle = null;
private $modified = false;

public static function wrap()
{
  stream_wrapper_unregister('file');
  if (!stream_wrapper_register('file', __CLASS__))
    throw new Exception('Failed to register');
}

public static function unwrap()
{
  //echo "unwrap<br />\n";
  stream_wrapper_restore('file');
}

public static function getModifiedPaths()
{
  return array_unique(self::$modified_paths);
}

public static function addModifiedPath($path)
{
  self::$modified_paths[] = $path;
}

public function stream_write($data)
{
  if (!$this->modified)
  {
    $this->modified = true;
    self::$modified_paths[] = $this->path;
  }

  return fwrite($this->handle, $data);
}
```

... and the rest of the interface implemented

Between stream_wrapper_unregister('file'); and stream_wrapper_register('file', **CLASS**); php could not find any class files (including the Exception which we try to throw if registering fails)

My current solution is to explicitly use the php_plain_files_wrapper in xcache.

Thanks in advance, i love using xcache
